### PR TITLE
An extremely simple function to slice keyboard variants to avoid overflow of text when using vertical bars

### DIFF
--- a/.config/quickshell/ii/modules/bar/HyprlandXkbIndicator.qml
+++ b/.config/quickshell/ii/modules/bar/HyprlandXkbIndicator.qml
@@ -6,9 +6,15 @@ import qs.modules.common.widgets
 Loader {
     id: root
     property bool vertical: false
-
     active: HyprlandXkb.layoutCodes.length > 1
     visible: active
+
+    function abbreviateLayoutCode(fullCode) {
+        return fullCode.split(':').map(layout => {
+                const baseLayout = layout.split('-')[0];
+                return baseLayout.length > 4 ? baseLayout.slice(0, 4) : baseLayout;
+            }).join('\n');
+        }
 
     sourceComponent: Item {
         implicitWidth: root.vertical ? null : layoutCodeText.implicitWidth
@@ -18,7 +24,7 @@ Loader {
             id: layoutCodeText
             anchors.centerIn: parent
             horizontalAlignment: Text.AlignHCenter
-            text: HyprlandXkb.currentLayoutCode.split(":").join("\n")
+            text: abbreviateLayoutCode(HyprlandXkb.currentLayoutCode)
             font.pixelSize: text.includes("\n") ? Appearance.font.pixelSize.smallie : Appearance.font.pixelSize.small
             color: rightSidebarButton.colText
             animateChange: true


### PR DESCRIPTION
## Describe your changes

I added a function that slices keyboard variants to be at most 4 characters long to avoid text overflow, especially when you set the bar to be vertical.

## Is it ready? Questions/feedback needed?

I've tested it out with:
- us-colemak
- us-devorak
- us-workman
- fr-bepo
- gr-polytonic

https://github.com/user-attachments/assets/c3aa5938-f4b9-49b2-94a8-b701459ed0c4

https://github.com/user-attachments/assets/fa1d4eb1-be92-451a-8768-157682f1cbe8

